### PR TITLE
Skip wait cycles in fast keyboard polling code in IRQ handler

### DIFF
--- a/petterm.s
+++ b/petterm.s
@@ -717,17 +717,17 @@ IRQHDLR	SUBROUTINE ; 36 cycles till we hit here from IRQ firing
 	JMP	.keyend
 	
 .fastkbd
+	DEC POLLTGT
+	BEQ	.final		; 0 - finish pull run
 	LDA	POLLTGT
-	BEQ	.final		; 0 
 	CMP	#$11
-	BEQ	.first		; 12
-	; One of the 10 scanning rows ;1-11
+	BEQ	.first		; 11 - setup poll run
+	BCS .exit		; > 11 - counting down to run
+	; One of the 10 scanning rows ;1-10
 	JSR	KBDROWPOLL
-	DEC	POLLTGT
 	JMP	.exit
 .first	
 	JSR	KBDROWSETUP
-	DEC	POLLTGT
 	JMP	.exit
 .final
 	LDA	POLLRES

--- a/petterm.s
+++ b/petterm.s
@@ -718,10 +718,10 @@ IRQHDLR	SUBROUTINE ; 36 cycles till we hit here from IRQ firing
 	
 .fastkbd
 	DEC POLLTGT
-	BEQ	.final		; 0 - finish pull run
+	BEQ	.final		; 0 - finish polling run
 	LDA	POLLTGT
 	CMP	#$11
-	BEQ	.first		; 11 - setup poll run
+	BEQ	.first		; 11 - setup polling run
 	BCS .exit		; > 11 - counting down to run
 	; One of the 10 scanning rows ;1-10
 	JSR	KBDROWPOLL

--- a/petterm.s
+++ b/petterm.s
@@ -720,7 +720,7 @@ IRQHDLR	SUBROUTINE ; 36 cycles till we hit here from IRQ firing
 	DEC POLLTGT
 	BEQ	.final		; 0 - finish polling run
 	LDA	POLLTGT
-	CMP	#$11
+	CMP	#11
 	BEQ	.first		; 11 - setup polling run
 	BCS .exit		; > 11 - counting down to run
 	; One of the 10 scanning rows ;1-10


### PR DESCRIPTION
The fast keyboard polling code in the IRQ handler currently doesn't skip the waiting cycles as it counts down POLLTGT from POLLRES to 11. Instead, it treats values > 11 as scanning rows. This makes KBDROWPOLL attempt to scan key rows with indices > 9, which don't exist.
I've also moved the decreasing of POLLTGT to just before the evaluation of POLLTGT's value, which means it only needs to be included once in the fast keyboard poll section of the IRQ handler. It is also more consistent with the structure of the slow keyboard polling code.